### PR TITLE
refactor: sqlite接続をwith文で管理するように変更

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -14,19 +14,18 @@ def get_connection() -> sqlite3.Connection:
     return sqlite3.connect(DB_PATH)
 
 def init_db() -> None:
-    conn = get_connection()
-    cursor = conn.cursor()
+    with get_connection() as conn:
+        cursor = conn.cursor()
 
-    cursor.execute("""
-    CREATE TABLE IF NOT EXISTS sales (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        date TEXT NOT NULL,
-        store TEXT NOT NULL,
-        product TEXT NOT NULL,
-        category TEXT NOT NULL,
-        amount INTEGER NOT NULL
-    )
-    """)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS sales (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT NOT NULL,
+            store TEXT NOT NULL,
+            product TEXT NOT NULL,
+            category TEXT NOT NULL,
+            amount INTEGER NOT NULL
+        )
+        """)
 
-    conn.commit()
-    conn.close()
+        conn.commit()

--- a/core/repository.py
+++ b/core/repository.py
@@ -6,78 +6,70 @@ from core.db import get_connection
 
 
 def add_sale(date: str, store: str, product: str, category: str, amount:int) -> None:
-    conn = get_connection()
-    cursor = conn.cursor()
+    with get_connection() as conn:
+        cursor = conn.cursor()
 
-    cursor.execute("""
-    INSERT INTO sales (date, store, product, category, amount)
-    VALUES (?, ?, ?, ?, ?)
-    """, (date, store, product, category, amount))
+        cursor.execute("""
+        INSERT INTO sales (date, store, product, category, amount)
+        VALUES (?, ?, ?, ?, ?)
+        """, (date, store, product, category, amount))
 
-    conn.commit()
-    conn.close()
+        conn.commit()
 
 def get_all_sales():
-    conn = get_connection()
-    cursor = conn.cursor()
-
-    cursor.execute("SELECT * FROM sales ORDER BY date")
-    rows = cursor.fetchall()
-
-    conn.close()
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM sales ORDER BY date")
+        rows = cursor.fetchall()
     return rows
 
 def get_sales(store: str, date: str):
-    conn = get_connection()
-    cursor = conn.cursor()
+    with get_connection() as conn:
+        cursor = conn.cursor()
 
-    cursor.execute("""
-            SELECT * FROM sales 
-            WHERE store = ? AND date = ?
-            """,(store,date))
-    rows = cursor.fetchall()
-
-    conn.close()
+        cursor.execute("""
+                SELECT * FROM sales 
+                WHERE store = ? AND date = ?
+                """,(store,date))
+        rows = cursor.fetchall()
     return rows
 
 def get_sales_summary_by_store():
-    conn = get_connection()
-    cursor = conn.cursor()
+    with get_connection() as conn:
+        cursor = conn.cursor()
 
-    query = """
-            SELECT store, SUM(amount)
-            FROM sales
-            GROUP BY store
-            ORDER BY SUM(amount) DESC            
-            """
-    cursor.execute(query)
-    rows = cursor.fetchall()
+        query = """
+                SELECT store, SUM(amount)
+                FROM sales
+                GROUP BY store
+                ORDER BY SUM(amount) DESC            
+                """
+        cursor.execute(query)
+        rows = cursor.fetchall()
 
-    conn.close()
     return rows
 
 def get_sales_summary_by_date():
-    conn = get_connection()
-    cursor = conn.cursor()
+    with get_connection() as conn:
+        cursor = conn.cursor()
 
-    query = """
-            SELECT date, SUM(amount)
-            FROM sales
-            GROUP BY date
-            ORDER BY SUM(amount) DESC            
-            """
-    cursor.execute(query)
-    rows = cursor.fetchall()
+        query = """
+                SELECT date, SUM(amount)
+                FROM sales
+                GROUP BY date
+                ORDER BY SUM(amount) DESC            
+                """
+        cursor.execute(query)
+        rows = cursor.fetchall()
 
-    conn.close()
     return rows
 
 def delete_all_sales():
-    conn = get_connection()
-    cursor = conn.cursor()
+    with get_connection() as conn:
+        cursor = conn.cursor()
 
-    query = "DELETE FROM sales"
-    cursor.execute(query)
+        query = "DELETE FROM sales"
+        cursor.execute(query)
 
-    conn.commit()
-    conn.close()
+        conn.commit()
+    


### PR DESCRIPTION
## 概要
sqlite接続をwith文で管理するように変更

## 変更内容
- `repository.py`と`db.py`のsqlite接続箇所をwith文で全部変更

## 確認方法
- python run.py で正常動作する
- Excelインポートできる
- 集計できる
- Excel出力できる

Closes #1 
