### PR TITLE
feat: Excel出力シート名をconfig.iniから読み込むように変更

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,4 @@
+[excel]
+sheet_store = store
+sheet_date = date
+

--- a/core/config_loader.py
+++ b/core/config_loader.py
@@ -1,0 +1,10 @@
+from configparser import ConfigParser
+from pathlib import Path
+
+config = ConfigParser()
+
+config_path = Path(__file__).resolve().parent.parent / "config.ini"
+config.read(config_path, encoding="utf-8")
+
+EXCEL_SHEET_STORE = config.get("excel", "sheet_store", fallback="store")
+EXCEL_SHEET_DATE = config.get("excel", "sheet_date", fallback="date")

--- a/core/service.py
+++ b/core/service.py
@@ -38,9 +38,10 @@ def export_report_to_excel(file_path: str, reports_list: list[dict]) -> None:
 
     with pd.ExcelWriter(report_path, engine="openpyxl") as writer:
         for report in reports_list:
+            sheet_name = report["sheet_name"]
             df = pd.DataFrame(
                 report["sales_summary"],
-                columns=[report["sheet_name"], "total_amount"]
+                columns=[sheet_name, "total_amount"]
             )
             df.to_excel(writer, sheet_name=report["sheet_name"], index=False)
 

--- a/run.py
+++ b/run.py
@@ -11,6 +11,7 @@ from core.repository import (
     get_sales_summary_by_date
 )
 from core.service import import_sales_from_excel,export_report_to_excel
+from core.config_loader import EXCEL_SHEET_DATE, EXCEL_SHEET_STORE
 
 from pathlib import Path
 
@@ -47,8 +48,8 @@ def main() -> None:
     print("Excel出力")
     output_file_path = "output/report.xlsx"
     reports_list = [
-        {"sales_summary": sales_summary_store, "sheet_name": "store"},
-        {"sales_summary": sales_summary_date, "sheet_name": "date"}
+        {"sales_summary": sales_summary_store, "sheet_name": EXCEL_SHEET_STORE},
+        {"sales_summary": sales_summary_date, "sheet_name": EXCEL_SHEET_DATE}
     ]
     export_report_to_excel(output_file_path, reports_list)
 


### PR DESCRIPTION
## 概要
出力シート名がコードに直書きだったので、config.iniに外出し

## 変更内容
- プロジェクト直下に`config.ini`作成
- `core/config_loader.py`の追加
- `core/service.py`と`run.py`を修正

## 確認方法
- config.iniを変更して、変更した値でシート名が書き換わるかを確認

Closes #3 
