### PR TITLE
feat: config対応とCLI引数による入出力指定を追加

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -4,3 +4,6 @@ sheet_date = date
 sheet_category = category
 sheet_product = product
 
+[paths]
+default_input = input/sales.xlsx
+default_output = output/report.xlsx

--- a/core/config_loader.py
+++ b/core/config_loader.py
@@ -10,3 +10,6 @@ EXCEL_SHEET_STORE = config.get("excel", "sheet_store", fallback="store")
 EXCEL_SHEET_DATE = config.get("excel", "sheet_date", fallback="date")
 EXCEL_SHEET_CATEGORY = config.get("excel", "sheet_category", fallback="category")
 EXCEL_SHEET_PRODUCT = config.get("excel", "sheet_product", fallback="product")
+
+DEFAULT_INPUT = config.get("paths", "default_input", fallback="input/sales.xlsx")
+DEFAULT_OUTPUT = config.get("paths", "default_output", fallback="output/report.xlsx")

--- a/run.py
+++ b/run.py
@@ -1,11 +1,11 @@
 # ====================
 #  メインの実行ファイルになる場所
 # ====================
+from pathlib import Path
+import argparse
 
 from core.db import init_db
 from core.repository import (
-    get_all_sales, 
-    get_sales,
     get_sales_summary_by_store,
     delete_all_sales,
     get_sales_summary_by_date,
@@ -13,49 +13,51 @@ from core.repository import (
     get_sales_summary_by_product
 )
 from core.service import import_sales_from_excel,export_report_to_excel
-from core.config_loader import EXCEL_SHEET_DATE, EXCEL_SHEET_STORE, EXCEL_SHEET_CATEGORY, EXCEL_SHEET_PRODUCT
+from core.config_loader import (
+    EXCEL_SHEET_DATE,
+    EXCEL_SHEET_STORE,
+    EXCEL_SHEET_CATEGORY,
+    EXCEL_SHEET_PRODUCT,
+    DEFAULT_INPUT,
+    DEFAULT_OUTPUT
+)
 
-from pathlib import Path
+def parse_args():
+    parser = argparse.ArgumentParser(description="Sales Excel Import/Export tool")
+
+    parser.add_argument("--input", help="入力Excelファイルのパス")
+    parser.add_argument("--output", help="出力Excelファイルのパス")
+
+    return parser.parse_args()
+
 
 def main() -> None:
+    args = parse_args()
+
+    input_file_path = Path(args.input or DEFAULT_INPUT)
+    output_file_path = Path(args.output or DEFAULT_OUTPUT)
+
+    if not input_file_path.exists():
+        raise FileNotFoundError(f"入力ファイルが存在しません：{input_file_path}")
+
     init_db()
     print("データベースの初期化が完了しました。")
 
     # salesのデータ削除
     delete_all_sales()
 
-    input_file_path = "input/sales.xlsx"
-    import_sales_from_excel(input_file_path)
+    import_sales_from_excel(str(input_file_path))
 
-    print("----- 東京店かつ2026-04-01で取得 -----")
-    sales_tokyo = get_sales("東京店", "2026-04-01")
-    for row in sales_tokyo:
-        print(row)
+    print("Excel出力中...")
 
-    print("----- 全件取得 -----")
-    sales = get_all_sales()
-    for row in sales:
-        print(row)
-
-    print("-----店別集計-----")
-    sales_summary_store = get_sales_summary_by_store()
-    for store, total in sales_summary_store:
-        print(f"{store}: {total}円")
-    
-    print("-----日別集計-----")
-    sales_summary_date = get_sales_summary_by_date()
-    for date, total in sales_summary_date:
-        print(f"{date}: {total}円")
-
-    print("Excel出力")
-    output_file_path = "output/report.xlsx"
     reports_list = [
         {"sales_summary": get_sales_summary_by_store(), "sheet_name": EXCEL_SHEET_STORE},
         {"sales_summary": get_sales_summary_by_date(), "sheet_name": EXCEL_SHEET_DATE},
         {"sales_summary": get_sales_summary_by_category(), "sheet_name": EXCEL_SHEET_CATEGORY},
         {"sales_summary": get_sales_summary_by_product(), "sheet_name": EXCEL_SHEET_PRODUCT}
     ]
-    export_report_to_excel(output_file_path, reports_list)
+    export_report_to_excel(str(output_file_path), reports_list)
+    print("完了しました。")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
CLIで引数指定してインプットファイルとアウトプットファイルのパス指定ができるようにした。

## 変更内容
- `run.py`に`parse_args()`を追加
- config.iniに`default_input`と`default_output`を追加

## 確認方法
- `python run.py --input {input_file_path} --output {output_file_path}`で実行できること。
- 指定した入出力ファイルで動作すること。
- 引数を指定しない場合、config.iniの値が使用されること。

Closes #4 
