### PR TITLE
feat: サービスロジックの共通化

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -5,7 +5,23 @@
 from pathlib import Path
 import pandas as pd
 
-from core.repository import add_sale
+from core.db import init_db
+from core.repository import (
+    delete_all_sales,
+    add_sale,
+    get_sales_summary_by_store,
+    get_sales_summary_by_date,
+    get_sales_summary_by_category,
+    get_sales_summary_by_product
+)
+
+from core.config_loader import (
+    EXCEL_SHEET_DATE,
+    EXCEL_SHEET_STORE,
+    EXCEL_SHEET_CATEGORY,
+    EXCEL_SHEET_PRODUCT
+)
+
 from logging import getLogger
 
 logger = getLogger(__name__)
@@ -55,4 +71,25 @@ def export_report_to_excel(file_path: str, reports_list: list[dict]) -> None:
             df.to_excel(writer, sheet_name=report["sheet_name"], index=False)
     
     logger.info("Export completed")
+
+def process_sales_report(input_file_path: Path, output_file_path: Path) -> None:
+    
+    # DB初期化
+    init_db()
+
+    # salesのデータ削除
+    delete_all_sales()
+
+    # excelのデータをDBに取り込み
+    import_sales_from_excel(str(input_file_path))
+
+    reports_list = [
+        {"sales_summary": get_sales_summary_by_store(), "sheet_name": EXCEL_SHEET_STORE},
+        {"sales_summary": get_sales_summary_by_date(), "sheet_name": EXCEL_SHEET_DATE},
+        {"sales_summary": get_sales_summary_by_category(), "sheet_name": EXCEL_SHEET_CATEGORY},
+        {"sales_summary": get_sales_summary_by_product(), "sheet_name": EXCEL_SHEET_PRODUCT}
+    ]
+
+    # エクスポート処理
+    export_report_to_excel(str(output_file_path), reports_list)
 

--- a/gui/gui_app.py
+++ b/gui/gui_app.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from tkinter.scrolledtext import ScrolledText
 from tkinter import filedialog
 from typing import Dict
+from core.service import process_sales_report
+from core.config_loader import DEFAULT_INPUT, DEFAULT_OUTPUT
 
 
 # --- GUI本体 ---
@@ -16,6 +18,15 @@ def gui_main():
         import_path = Path(import_var.get())
         export_path = Path(export_folder_var.get()) / (export_file_var.get() + ".xlsx")
         return {"import_path" : import_path, "export_path": export_path}
+    
+    def worker():
+        try:
+            setting = get_setting_info()
+            input_file_path = setting.get("import_path") or Path(DEFAULT_INPUT)
+            output_file_path = setting.get("export_path") or Path(DEFAULT_OUTPUT)
+            process_sales_report(input_file_path, output_file_path)
+        except Exception as e:
+            print("Unexpected error occurred:", str(e))
 
     root = tk.Tk()
     root.title("売上レポート管理ツール")
@@ -44,7 +55,7 @@ def gui_main():
     export_file_extention = tk.Label(root, text=".xlsx").grid(row=2,column=2 )
 
     # 実行ボタン
-    run_button = tk.Button(root, text="実行", command=get_setting_info).grid(row=3, column=1)
+    run_button = tk.Button(root, text="実行", command=worker).grid(row=3, column=1)
 
     # ログ表示ボックス
     log_box = ScrolledText(root, width=80, height=10)

--- a/run.py
+++ b/run.py
@@ -4,24 +4,9 @@
 from pathlib import Path
 import argparse
 
-from core.db import init_db
-from core.repository import (
-    get_sales_summary_by_store,
-    delete_all_sales,
-    get_sales_summary_by_date,
-    get_sales_summary_by_category,
-    get_sales_summary_by_product
-)
-from core.service import import_sales_from_excel,export_report_to_excel
-from core.config_loader import (
-    EXCEL_SHEET_DATE,
-    EXCEL_SHEET_STORE,
-    EXCEL_SHEET_CATEGORY,
-    EXCEL_SHEET_PRODUCT,
-    DEFAULT_INPUT,
-    DEFAULT_OUTPUT
-)
-import core.logger_setup 
+from core.service import process_sales_report
+from core.config_loader import DEFAULT_INPUT, DEFAULT_OUTPUT
+import core.logger_setup # 読み込むだけ
 from logging import getLogger
 
 logger = getLogger(__name__)
@@ -48,26 +33,16 @@ def cli_main() -> None:
         logger.info("Application started")
         args = parse_args()
 
+        # 入出力を引数から取得
         input_file_path = Path(args.input or DEFAULT_INPUT)
         output_file_path = Path(args.output or DEFAULT_OUTPUT)
 
         if not input_file_path.exists():
             raise FileNotFoundError(f"入力ファイルが存在しません：{input_file_path}")
+        
+        # 業務ロジック実行
+        process_sales_report(input_file_path, output_file_path)
 
-        init_db()
-
-        # salesのデータ削除
-        delete_all_sales()
-
-        import_sales_from_excel(str(input_file_path))
-
-        reports_list = [
-            {"sales_summary": get_sales_summary_by_store(), "sheet_name": EXCEL_SHEET_STORE},
-            {"sales_summary": get_sales_summary_by_date(), "sheet_name": EXCEL_SHEET_DATE},
-            {"sales_summary": get_sales_summary_by_category(), "sheet_name": EXCEL_SHEET_CATEGORY},
-            {"sales_summary": get_sales_summary_by_product(), "sheet_name": EXCEL_SHEET_PRODUCT}
-        ]
-        export_report_to_excel(str(output_file_path), reports_list)
         logger.info("Application finished")
     
     except Exception as e:


### PR DESCRIPTION
## 概要
GUI側でも使用できるように業務ロジックを共通化した。

## 変更内容
- `run.py`内で実施していた処理を`service.py`に移した。
- `gui_app.py`でも業務ロジックが実行できるようにした。

## 確認方法
- CLI実行で業務ロジックが問題なく動くこと。
- `python run.py --gui`でGUIが起動し、業務ロジックが実行できること。

Closes #18 
